### PR TITLE
Match updated protocol

### DIFF
--- a/AUIT/Assets/AUIT/Extras/EvaluationRequest.cs
+++ b/AUIT/Assets/AUIT/Extras/EvaluationRequest.cs
@@ -8,12 +8,12 @@ namespace AUIT.Extras
     [Serializable]
     public class EvaluationRequest
     {
-        public string[] layouts;
+        public string[] items;
 
 
         public override string ToString()
         {
-            return layouts.First().ToString();
+            return items.First().ToString();
         }
     }
     

--- a/AUIT/Assets/AUIT/Extras/UIConfiguration.cs
+++ b/AUIT/Assets/AUIT/Extras/UIConfiguration.cs
@@ -8,19 +8,19 @@ namespace AUIT.Extras
     [Serializable]
     public class UIConfiguration
     {
-        public Layout[] elements;
+        public Layout[] items;
 
         public static UIConfiguration FromLayout(Layout layout)
         {
             UIConfiguration config = new UIConfiguration();
-            config.elements = new Layout[1];
-            config.elements[0] = layout;
+            config.items = new Layout[1];
+            config.items[0] = layout;
             return config;
         }
 
         public override string ToString()
         {
-            return elements.First().ToString();
+            return items.First().ToString();
         }
     }
 }


### PR DESCRIPTION
I have updated the `UIConfiguration` and `EvaluationRequest` classes to match your changes to the protocol. At least on my machine, this is working with the current `main` branch version of `auit-pareto-solver`.