### PR TITLE
Implement neck and arm angle objectives and fix multi-objective evaluation

### DIFF
--- a/AUIT/Assets/AUIT/AdaptationObjectives/ArmAngleObjective.cs
+++ b/AUIT/Assets/AUIT/AdaptationObjectives/ArmAngleObjective.cs
@@ -1,0 +1,80 @@
+﻿using AUIT.AdaptationObjectives.Definitions;
+using AUIT.AdaptationObjectives.Extras;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace AUIT.AdaptationObjectives
+{
+    /// <summary>
+    /// This objective is used to minimize the angle between the vector from the
+    /// shoulder position straight down to the ground (i.e., resting arm position)
+    /// and the vector from the shoulder position to the target.
+    /// It is a simplified arm/shoulder ergonomics objective based on RULA.
+    /// </summary>
+    public class ArmAngleObjective : LocalObjective
+    {
+        [SerializeField]
+        private float eyeToShoulderDistance = 0.25f;
+
+        private float GetNormalizedArmAngle(Vector3 targetPosition, Vector3 shoulderPosition)
+        {
+            // If the target is on the shoulder position, we return 1.
+            if (targetPosition == shoulderPosition)
+            {
+                return 1.0f;
+            }
+
+            // Get the vector from the shoulder position to the target.
+            Vector3 shoulderToTarget = targetPosition - shoulderPosition;
+
+            // Get the vector from the shoulder position straight down to the ground.
+            Vector3 shoulderToGround = new Vector3(0, -1, 0);
+
+            // Get the angle between the two vectors.
+            float angle = Vector3.Angle(shoulderToTarget, shoulderToGround);
+
+            // Normalize the angle to the interval [0, 1].
+            float normalizedAngle = angle / 180;
+
+            return normalizedAngle;
+        }
+
+        /// <summary>
+        /// Returns the arm angle normalized to the interval [0, 1].
+        /// An arm angle of 0 means that the target is right below the shoulder joint (i.e.,
+        /// the user can interact with the target without lifting the arm).
+        /// An arm angle of 1 means that the target is on or right above the shoulder joint (i.e.,
+        /// the user has to lift the arm fully to interact with the target).
+        /// An arm angle of 0.5 means that the target is right at the level of the shoulder joint.
+        /// WARN: These are not realistic scenarios, but are used to test the objective.
+        /// Whether the user can interact with the target depends on the target's size and
+        /// the user's arm length.
+        /// </summary>
+        public override float CostFunction(Layout optimizationTarget, Layout initialLayout = null)
+        {
+            Vector3 targetPosition = (Vector3)ContextSourceTransformTarget;
+            Vector3 currentPosition = optimizationTarget.Position;
+
+            // Calculate the shoulder position (the shoulder is eyeToShoulderDistance below the eye)
+            Vector3 shoulderPosition = currentPosition;
+            shoulderPosition.y -= eyeToShoulderDistance;
+
+            // Calculate the normalized arm angle
+            float normalizedAngle = GetNormalizedArmAngle(targetPosition, shoulderPosition);
+
+            return normalizedAngle;
+        }
+
+        public override Layout OptimizationRule(Layout optimizationTarget, Layout initialLayout)
+        {
+            // Do nothing for now.
+            return optimizationTarget;
+        }
+
+        public override Layout DirectRule(Layout optimizationTarget)
+        {
+            // Do nothing for now.
+            return optimizationTarget;
+        }
+    }
+}

--- a/AUIT/Assets/AUIT/AdaptationObjectives/NeckAngleObjective.cs
+++ b/AUIT/Assets/AUIT/AdaptationObjectives/NeckAngleObjective.cs
@@ -1,0 +1,78 @@
+﻿using AUIT.AdaptationObjectives.Definitions;
+using AUIT.AdaptationObjectives.Extras;
+using UnityEngine;
+
+using Random = UnityEngine.Random;
+
+namespace AUIT.AdaptationObjectives
+{
+    /// <summary>
+    /// This objective is used to minimize the angle between the vector from the
+    /// eye position to the GameObject and the vector from the eye position to the
+    /// target's projection on the xz-plane at the eye position's height.
+    /// It is a simplified neck ergonomics objective based on RULA.
+    /// </summary>
+    public class NeckAngleObjective : LocalObjective
+    {
+        private float GetNormalizedNeckAngle(Vector3 targetPosition, Vector3 currentEyePosition)
+        {
+            // If the target is on, right below or above the eye position, we return 1.
+            if (
+                targetPosition.x == currentEyePosition.x &&
+                targetPosition.z == currentEyePosition.z
+            )
+            {
+                return 1.0f;
+            }
+
+            // Get the vector from the eye position to the target.
+            Vector3 eyeToTarget = targetPosition - currentEyePosition;
+
+            // Get the vector from the eye position to the target's projection on the xz-plane
+            // at the eye position's height.
+            Vector3 eyeToTargetProjection =
+                new Vector3(eyeToTarget.x, 0, eyeToTarget.z);
+
+            // Get the angle between the two vectors.
+            float angle = Vector3.Angle(eyeToTarget, eyeToTargetProjection);
+
+            // Normalize the angle to the interval [0, 1].
+            float normalizedAngle = angle / 90;
+
+            return normalizedAngle;
+        }
+
+        /// <summary>
+        /// Returns the neck angle normalized to the interval [0, 1].
+        /// A neck angle of 0 means that the target is at eye level of the user but not at the eye position.
+        /// A neck angle of 1 means that the target is right below the user's head (i.e.,
+        /// the user has to look down at a 90 degree angle to see the target), right above
+        /// the user's head (i.e., the user has to look up at a 90 degree angle to see the target),
+        /// or on the user's eye position.
+        /// A neck angle of 0.5 means that the target is at a 45 degree angle in front of the user,
+        /// either above or below the user's head.
+        /// </summary>
+        public override float CostFunction(Layout optimizationTarget, Layout initialLayout = null)
+        {
+            Vector3 targetPosition = (Vector3) ContextSourceTransformTarget;
+            Vector3 currentEyePosition = optimizationTarget.Position; // This is technically the camera position.
+
+            float normalizedAngle =
+                GetNormalizedNeckAngle(targetPosition, currentEyePosition);
+
+            return normalizedAngle;
+        }
+
+        public override Layout OptimizationRule(Layout optimizationTarget, Layout initialLayout)
+        {
+            // Do nothing for now.
+            return optimizationTarget;
+        }
+
+        public override Layout DirectRule(Layout optimizationTarget)
+        {
+            // Do nothing for now.
+            return optimizationTarget;
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I have implemented simple objectives for the neck and arm angle. When running the optimization for both, I found that the format for the EvaluationResponse did not match, so I fixed that in the AdaptationManager. Now, for each candidate layout $l_1$, $l_2$, ... in a population, the response has a format like this: costs: [[ $armAngleCost_1$, $neckAngleCost_1$ ], [ $armAngleCost_2$, $neckAngleCost_2$ ], ...].