### PR TITLE
Work with updated OptRes protocol

### DIFF
--- a/AUIT/Assets/AUIT/AdaptationObjectives/Definitions/Wrapper.cs
+++ b/AUIT/Assets/AUIT/AdaptationObjectives/Definitions/Wrapper.cs
@@ -7,11 +7,6 @@ namespace AUIT.AdaptationObjectives.Definitions
     public class Wrapper<T>
     {
         public T[] items;
-
-        // public override string ToString()
-        // {
-        //     return string.Join(",", array);
-        // }
     }
     
     

--- a/AUIT/Assets/AUIT/Extras/OptimizationResponse.cs
+++ b/AUIT/Assets/AUIT/Extras/OptimizationResponse.cs
@@ -1,5 +1,6 @@
 using System;
 using AUIT.AdaptationObjectives.Definitions;
+using UnityEngine;
 using UnityEngine.Serialization;
 
 namespace AUIT.Extras
@@ -7,7 +8,7 @@ namespace AUIT.Extras
     [Serializable]
     public class OptimizationResponse
     {
-        public UIConfiguration[] solutions;
+        public string solutions;  // will be UIConfiguration[]
+        public string suggested;  // will be UIConfiguration
     }
-
 }

--- a/AUIT/Assets/AUIT/Solvers/ParetoFrontierSolver.cs
+++ b/AUIT/Assets/AUIT/Solvers/ParetoFrontierSolver.cs
@@ -152,18 +152,24 @@ namespace AUIT.Solvers
                 yield return null;
             }
 
-            Debug.Log(result);
+            // Debug.Log(result);
             
-            var optimizationResponse = JsonUtility.FromJson<Wrapper<string>>(result.Substring(1));
-            List<List<Layout>> layouts = new List<List<Layout>>(); 
-            foreach (var layoutString in optimizationResponse.items)
+            var optimizationResponse = JsonUtility.FromJson<OptimizationResponse>(result.Substring(1));
+            var solutions = JsonUtility.FromJson<Wrapper<string>>(optimizationResponse.solutions);
+            List<List<Layout>> suggestedUIConfigurations = new List<List<Layout>>(); // List of UI configurations to store suggested adaptations
+            // For each adaptation (i.e., new UI configuration) in the returned solutions
+            foreach (var suggestedUIConfigurationString in solutions.items)
             {
-                var e = JsonUtility.FromJson<Wrapper<Layout>>(layoutString);
-                layouts.Add(e.items.ToList());
+                // Convert the string to a list of Layout objects and add it to the list of suggested UI configurations
+                var suggestedUIConfiguration = JsonUtility.FromJson<Wrapper<Layout>>(suggestedUIConfigurationString);
+                suggestedUIConfigurations.Add(suggestedUIConfiguration.items.ToList());
             }
 
+            // Suggested layout for next active adaptation
+            var suggestedAdaptation = JsonUtility.FromJson<Wrapper<Layout>>(optimizationResponse.suggested);
+
             // todo: add costs
-            Result = (layouts, 0f, 0f);
+            Result = (suggestedUIConfigurations, 0f, 0f);
 
         }
 


### PR DESCRIPTION
I have updated the OptimizationResponse to have the fields `"solutions": {"items" [<UIConfiguration>]}` and `"suggested": <UIConfiguration>` as specified in the updated protocol. I decided to follow your advice and rename the "default" field to avoid any conflicts with C# protected global names.
For the updated protocol docs, see [auit-pareto-solver](https://github.com/christophajohns/auit-pareto-solver/blob/main/docs/protocol.md). To test this PR with the Python backend, the Python solver needs to be up to date with the GitHub repo's main branch.
I could not see any grey spheres, but I got the "could apply result!" log message.